### PR TITLE
Second assignment to an attribute does overwrite

### DIFF
--- a/src/BelongsTo.php
+++ b/src/BelongsTo.php
@@ -69,15 +69,16 @@ trait BelongsTo
             return null;
         }
 
-        if (array_key_exists($attr, $this->_belongs_cache) && $this->_belongs_cache[$attr]) {
-            return $this->_belongs_cache[$attr];
-        }
-
         $configs       = self::$_belongs_to[$cls][$attr];
         $belongs_cls   = is_array($configs) && array_key_exists("class_name",  $configs) ? $configs["class_name"]  : ucfirst($attr);
         $belongs_key   = is_array($configs) && array_key_exists("foreign_key", $configs) ? $configs["foreign_key"] : strtolower($belongs_cls)."_id";
         $primary_key   = is_array($configs) && array_key_exists("primary_key", $configs) ? $configs["primary_key"] : "id";
         $value         = $values[$belongs_key];
+
+        if (array_key_exists($attr, $this->_belongs_cache) && $this->_belongs_cache[$attr] && $this->_belongs_cache[$attr]->$primary_key == $value) {
+            return $this->_belongs_cache[$attr];
+        }
+
         $obj           = $belongs_cls::first(array($primary_key => $value));
 
         if ($obj) {

--- a/test/modelTest.php
+++ b/test/modelTest.php
@@ -623,6 +623,58 @@ class ModelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test whether a second BelongsTO assignment does change the attribute
+     * (Check if BelongsTo cache is properly updated)
+     *
+     * @return null
+     */
+    public function testBelongsDoubleAttribution()
+    {
+        $user1        = new User();
+        $user1->name  = "Belongs first attribution from where and other class";
+        $user1->email = "belongswhere@torm.com";
+        $user1->code  = "01011";
+        $user1->level = 1;
+        $this->assertTrue($user1->save());
+
+        $user2        = new User();
+        $user2->name  = "Belongs second attribution from where and other class";
+        $user2->email = "belongswhere2@torm.com";
+        $user2->code  = "01012";
+        $user2->level = 1;
+        $this->assertTrue($user2->save());
+
+        $uid1   = $user1->id;
+        $uname1 = $user1->name;
+
+        $uid2   = $user2->id;
+        $uname2 = $user2->name;
+
+        $users                = [$user1->code, $user2->code];
+        $ticket               = new Ticket();
+        $ticket->description  = "Test";
+        $ticket->user         = $user1;
+
+        $this->assertEquals($uname1, $ticket->user->name);
+        $ticket->user         = $user2;
+        $this->assertEquals($uname2, $ticket->user->name);
+
+        $this->assertTrue($ticket->save());
+
+        $this->assertNotEquals(self::$user->id, $uid1);
+        $this->assertNotEquals(self::$user->id, $uid2);
+
+        $this->assertNotNull($uid1);
+        $this->assertNotNull($uid2);
+
+        $this->assertEquals($ticket->user->id, $uid2);
+        $this->assertTrue($user1->destroy());
+        $this->assertTrue($user2->destroy());
+
+        $this->assertTrue($ticket->destroy());
+    }
+
+    /**
      * Test empty sequence
      *
      * @return null


### PR DESCRIPTION
BelongsTo cache was not updated properly after a belongsTo assignment.